### PR TITLE
add support for TimeStampMicroVector in FlightArrowColumnVector.java

### DIFF
--- a/src/main/java/org/apache/arrow/flight/spark/FlightArrowColumnVector.java
+++ b/src/main/java/org/apache/arrow/flight/spark/FlightArrowColumnVector.java
@@ -41,6 +41,7 @@ import org.apache.arrow.vector.Float4Vector;
 import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.SmallIntVector;
+import org.apache.arrow.vector.TimeStampMicroVector;
 import org.apache.arrow.vector.TimeStampMicroTZVector;
 import org.apache.arrow.vector.TimeStampMilliVector;
 import org.apache.arrow.vector.TimeStampVector;
@@ -200,8 +201,10 @@ public final class FlightArrowColumnVector extends ColumnVector {
       accessor = new DateAccessor((DateDayVector) vector);
     } else if (vector instanceof DateMilliVector) {
       accessor = new DateMilliAccessor((DateMilliVector) vector);
+    } else if (vector instanceof TimeStampMicroVector) {
+      accessor = new TimestampMicroAccessor((TimeStampMicroVector) vector);
     } else if (vector instanceof TimeStampMicroTZVector) {
-      accessor = new TimestampAccessor((TimeStampMicroTZVector) vector);
+      accessor = new TimestampMicroTZAccessor((TimeStampMicroTZVector) vector);
     } else if (vector instanceof TimeStampMilliVector) {
       accessor = new TimestampMilliAccessor((TimeStampMilliVector) vector);
     } else if (vector instanceof ListVector) {
@@ -480,11 +483,26 @@ public final class FlightArrowColumnVector extends ColumnVector {
     }
   }
 
-  private static class TimestampAccessor extends ArrowVectorAccessor {
+  private static class TimestampMicroAccessor extends ArrowVectorAccessor {
 
     private final TimeStampVector accessor;
 
-    TimestampAccessor(TimeStampMicroTZVector vector) {
+    TimestampMicroAccessor(TimeStampMicroVector vector) {
+      super(vector);
+      this.accessor = vector;
+    }
+
+    @Override
+    final long getLong(int rowId) {
+      return accessor.get(rowId);
+    }
+  }
+
+  private static class TimestampMicroTZAccessor extends ArrowVectorAccessor {
+
+    private final TimeStampVector accessor;
+
+    TimestampMicroTZAccessor(TimeStampMicroTZVector vector) {
       super(vector);
       this.accessor = vector;
     }


### PR DESCRIPTION
Needed in order to support the following parquet dataset:
https://s3.us-east-2.amazonaws.com/ursa-labs-taxi-data/2019/01/data.parquet

We intend to use it in the https://github.com/IBM/the-mesh-for-data-flight-module open-source repository.

Signed-off-by: Doron Chen <cdoron@il.ibm.com>