### PR TITLE
Migrate to GitHub Actions 

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -1,0 +1,23 @@
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: maven
+    - name: Build with Maven
+      run: mvn -B -V verify --file pom.xml

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -20,4 +20,4 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven
-      run: mvn -B -V verify --file pom.xml
+      run: mvn -B -V verify -Dmaven.javadoc.skip=true --file pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
           </inlineHeader>
           <properties>
-            <owner>The ${artifactId} Authors</owner>
+            <owner>The ${project.artifactId} Authors</owner>
             <project.inceptionYear>2019</project.inceptionYear>
           </properties>
           <project>


### PR DESCRIPTION
WIP. Please provide feedback!

This PR should do the following:
- Use GitHub Actions instead of Travis for building and publishing
- Publish to Maven central (if we believe this will take long, we can limit this PR scope to just GHA)

Note: The warnings about set-output and save-state in the workflows will be resolved whenever this actions setup-java change gets released in 3.5.X or 3.6. https://github.com/actions/setup-java/pull/390